### PR TITLE
Disable default automation

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -3,7 +3,8 @@
 /etc/init.d/pwrstatd start
 
 # disable automations
-pwrstat -lowbatt -capacity 0 -shutdown off -active off -runtime 0
-pwrstat -pwrfail -active off -shutdown off
+sleep 2
+/usr/sbin/pwrstat -lowbatt -capacity 0 -shutdown off -active off -runtime 0
+/usr/sbin/pwrstat -pwrfail -active off -shutdown off
 
 /app/pwrstat-exporter

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 /etc/init.d/pwrstatd start
+
+# disable automations
+pwrstat -lowbatt -capacity 0 -shutdown off -active off -runtime 0
+pwrstat -pwrfail -active off -shutdown off
+
 /app/pwrstat-exporter


### PR DESCRIPTION
By default pwrstat comes with automations (auto shutdown, sending email) 

This make sure the automation are disable when the process starts