### PR TITLE
Connection State Checking and Base Image Upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && \
     apt install wget -y && \
     wget -O PPL.deb https://dl4jz3rbrsfum.cloudfront.net/software/PPL_64bit_v1.4.1.deb && \
     dpkg -i PPL.deb && \
+    rm PPL.deb && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start with a minimal base image. This image will not need Go installed,
 # as we're copying a pre-compiled binary.
-FROM --platform=linux/amd64 debian:bullseye-slim AS runner
+FROM --platform=linux/amd64 debian:12.11-slim AS runner
 
 # Install dependencies required by your application or the init script.
 RUN apt update && \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,8 +2,14 @@
 
 /etc/init.d/pwrstatd start
 
+# wait until the daemon is sleeping (connected to the UPS)
+daemon_pid=$(cat /run/pwrstatd/pwrstatd.pid)
+while [[ "$(cat /proc/$daemon_pid/status | grep State | awk '{print $2}')" != "S" ]]; do
+  sleep 5
+  echo "Waiting for a connected daemon"
+done
+
 # disable automations
-sleep 2
 /usr/sbin/pwrstat -lowbatt -capacity 0 -shutdown off -active off -runtime 0
 /usr/sbin/pwrstat -pwrfail -active off -shutdown off
 


### PR DESCRIPTION
## Expected Results

1. By `script/init.sh`, the UPS should be connected in 2 seconds after `/etc/init.d/pwrstatd` launches a daemon. And `pwrstat` command runs fine.
2. The base image has a concrete tag for reproduceable builds.

## Actual Results

1. The UPS may not be connected in 2 seconds; e.g., sometimes 60 seconds in my setup. So, the following `pwrstat` commands silently fail, and `pwrstat-exporter` panics.
2. The base image tag only specifies the major Debian version.

## Container Logs

    ::Starting pwrstatd 1.4.1.
    Info::
     Address: http://localhost:8088/metrics
    panic: pwrstat missing

    goroutine 40 [running]:
    main.(*PwrstatCollector).Collect(0xbffce0, 0xc000226480)
      /app/main.go:79 +0x1285
    github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
      /app/vendor/github.com/prometheus/client_golang/prometheus/registry.go:446 +0x12b
    created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
      /app/vendor/github.com/prometheus/client_golang/prometheus/registry.go:457 +0x5ce


## Analysis and Solution

1. `/etc/init.d/pwrstatd` launches `/usr/sbin/pwrstatd` as a daemon and stores its PID in `/var/run/pwrstatd/pwrstatd.pid`.
2. By observation, such daemon process turns from running state to sleeping if it connects to a UPS (and it beeps). So, we can check the connection via the daemon state.
3. (Additional information) During connection initilization, `pwrstat` gives "No such file or directory" for non-help commands, and `pwrstat-exporter` panics.

## Environment

* Operating system: Debian 13
* Linux kernel and architecture: 6.12.38-1 (2025-07-16) x86_64
* Prometheus: v3.5.0

## Notes

1. 72b9668 cleans up the powerpanel installer to slim the image size.
2. `debian:trixie-slim` image does not ship with `/etc/init.d`. A manual directory creation can resolve errors during powerpanel installation, and everything works fine later on.